### PR TITLE
Fixed wasNotified access to public

### DIFF
--- a/Versioner/Version.swift
+++ b/Versioner/Version.swift
@@ -19,7 +19,7 @@ public struct Version {
     public var patch: Int
     public var build: Int = 0
 
-    var wasNotified: Bool {
+    public var wasNotified: Bool {
         get {
             return UserDefaults.standard.bool(forKey: versionUserDefaultKey)
         }


### PR DESCRIPTION
Property `wasNotified` has internal access and it is not accessible outside of the module.
With this fix, property is set to public.