### PR TITLE
Objective-C compatibility

### DIFF
--- a/PrinceOfVersions.xcodeproj/project.pbxproj
+++ b/PrinceOfVersions.xcodeproj/project.pbxproj
@@ -49,6 +49,7 @@
 		CF7576921DAC1FBA002B7581 /* Version.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF7576901DAC1F5E002B7581 /* Version.swift */; };
 		FE2232CD1ECF054E00D73F4D /* UpdateInfoResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE2232CC1ECF054E00D73F4D /* UpdateInfoResponse.swift */; };
 		FE2232CF1ECF058100D73F4D /* Result.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE2232CE1ECF058100D73F4D /* Result.swift */; };
+		FE2232D11ECF0DFA00D73F4D /* NotificationType.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE2232D01ECF0DFA00D73F4D /* NotificationType.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -90,6 +91,7 @@
 		CF7576901DAC1F5E002B7581 /* Version.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Version.swift; sourceTree = "<group>"; };
 		FE2232CC1ECF054E00D73F4D /* UpdateInfoResponse.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UpdateInfoResponse.swift; sourceTree = "<group>"; };
 		FE2232CE1ECF058100D73F4D /* Result.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Result.swift; sourceTree = "<group>"; };
+		FE2232D01ECF0DFA00D73F4D /* NotificationType.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NotificationType.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -141,6 +143,7 @@
 				FE2232CC1ECF054E00D73F4D /* UpdateInfoResponse.swift */,
 				FE2232CE1ECF058100D73F4D /* Result.swift */,
 				066F7F5C1D9126F00089F6F8 /* UpdateInfo.swift */,
+				FE2232D01ECF0DFA00D73F4D /* NotificationType.swift */,
 				CF7576901DAC1F5E002B7581 /* Version.swift */,
 			);
 			path = Versioner;
@@ -331,6 +334,7 @@
 				FE2232CF1ECF058100D73F4D /* Result.swift in Sources */,
 				FE2232CD1ECF054E00D73F4D /* UpdateInfoResponse.swift in Sources */,
 				CF7576911DAC1F5E002B7581 /* Version.swift in Sources */,
+				FE2232D11ECF0DFA00D73F4D /* NotificationType.swift in Sources */,
 				066396541D197C8800E8B7D2 /* PrinceOfVersions.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/PrinceOfVersions.xcodeproj/project.pbxproj
+++ b/PrinceOfVersions.xcodeproj/project.pbxproj
@@ -47,6 +47,8 @@
 		06C8F18A1D92BA150088BDA2 /* valid_update_only_min_version.json in Resources */ = {isa = PBXBuildFile; fileRef = 06C8F1761D92994E0088BDA2 /* valid_update_only_min_version.json */; };
 		CF7576911DAC1F5E002B7581 /* Version.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF7576901DAC1F5E002B7581 /* Version.swift */; };
 		CF7576921DAC1FBA002B7581 /* Version.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF7576901DAC1F5E002B7581 /* Version.swift */; };
+		FE2232CD1ECF054E00D73F4D /* UpdateInfoResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE2232CC1ECF054E00D73F4D /* UpdateInfoResponse.swift */; };
+		FE2232CF1ECF058100D73F4D /* Result.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE2232CE1ECF058100D73F4D /* Result.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -86,6 +88,8 @@
 		06C8F1781D929A4F0088BDA2 /* UpdateInfoTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UpdateInfoTest.swift; sourceTree = "<group>"; };
 		06C8F17B1D92A2680088BDA2 /* PrinceOfVersionsTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PrinceOfVersionsTest.swift; sourceTree = "<group>"; };
 		CF7576901DAC1F5E002B7581 /* Version.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Version.swift; sourceTree = "<group>"; };
+		FE2232CC1ECF054E00D73F4D /* UpdateInfoResponse.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UpdateInfoResponse.swift; sourceTree = "<group>"; };
+		FE2232CE1ECF058100D73F4D /* Result.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Result.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -134,6 +138,8 @@
 				06C2DF2B1D19639B0032E464 /* Versioner.h */,
 				06C2DF2D1D19639B0032E464 /* Info.plist */,
 				066396531D197C8800E8B7D2 /* PrinceOfVersions.swift */,
+				FE2232CC1ECF054E00D73F4D /* UpdateInfoResponse.swift */,
+				FE2232CE1ECF058100D73F4D /* Result.swift */,
 				066F7F5C1D9126F00089F6F8 /* UpdateInfo.swift */,
 				CF7576901DAC1F5E002B7581 /* Version.swift */,
 			);
@@ -322,6 +328,8 @@
 			buildActionMask = 2147483647;
 			files = (
 				066F7F5D1D9126F00089F6F8 /* UpdateInfo.swift in Sources */,
+				FE2232CF1ECF058100D73F4D /* Result.swift in Sources */,
+				FE2232CD1ECF054E00D73F4D /* UpdateInfoResponse.swift in Sources */,
 				CF7576911DAC1F5E002B7581 /* Version.swift in Sources */,
 				066396541D197C8800E8B7D2 /* PrinceOfVersions.swift in Sources */,
 			);

--- a/PrinceOfVersions.xcodeproj/project.pbxproj
+++ b/PrinceOfVersions.xcodeproj/project.pbxproj
@@ -9,8 +9,6 @@
 /* Begin PBXBuildFile section */
 		066396541D197C8800E8B7D2 /* PrinceOfVersions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 066396531D197C8800E8B7D2 /* PrinceOfVersions.swift */; };
 		066F7F5D1D9126F00089F6F8 /* UpdateInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 066F7F5C1D9126F00089F6F8 /* UpdateInfo.swift */; };
-		066F7F5E1D9126F00089F6F8 /* UpdateInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 066F7F5C1D9126F00089F6F8 /* UpdateInfo.swift */; };
-		066F7F5F1D912A190089F6F8 /* PrinceOfVersions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 066396531D197C8800E8B7D2 /* PrinceOfVersions.swift */; };
 		0688DB1B1D19AA460027695C /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0688DB1A1D19AA460027695C /* Foundation.framework */; };
 		0688DB1D1D19AA4B0027695C /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0688DB1C1D19AA4B0027695C /* UIKit.framework */; };
 		06C2DF2C1D19639B0032E464 /* Versioner.h in Headers */ = {isa = PBXBuildFile; fileRef = 06C2DF2B1D19639B0032E464 /* Versioner.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -46,7 +44,6 @@
 		06C8F1891D92BA150088BDA2 /* valid_update_notification_once.json in Resources */ = {isa = PBXBuildFile; fileRef = 06C8F1741D92991F0088BDA2 /* valid_update_notification_once.json */; };
 		06C8F18A1D92BA150088BDA2 /* valid_update_only_min_version.json in Resources */ = {isa = PBXBuildFile; fileRef = 06C8F1761D92994E0088BDA2 /* valid_update_only_min_version.json */; };
 		CF7576911DAC1F5E002B7581 /* Version.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF7576901DAC1F5E002B7581 /* Version.swift */; };
-		CF7576921DAC1FBA002B7581 /* Version.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF7576901DAC1F5E002B7581 /* Version.swift */; };
 		FE2232CD1ECF054E00D73F4D /* UpdateInfoResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE2232CC1ECF054E00D73F4D /* UpdateInfoResponse.swift */; };
 		FE2232CF1ECF058100D73F4D /* Result.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE2232CE1ECF058100D73F4D /* Result.swift */; };
 		FE2232D11ECF0DFA00D73F4D /* NotificationType.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE2232D01ECF0DFA00D73F4D /* NotificationType.swift */; };
@@ -344,9 +341,6 @@
 			buildActionMask = 2147483647;
 			files = (
 				06C8F17C1D92A2680088BDA2 /* PrinceOfVersionsTest.swift in Sources */,
-				CF7576921DAC1FBA002B7581 /* Version.swift in Sources */,
-				066F7F5E1D9126F00089F6F8 /* UpdateInfo.swift in Sources */,
-				066F7F5F1D912A190089F6F8 /* PrinceOfVersions.swift in Sources */,
 				06C8F1791D929A4F0088BDA2 /* UpdateInfoTest.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -405,6 +399,7 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
+				PRODUCT_MODULE_NAME = "$(PRODUCT_NAME:c99extidentifier)";
 				SDKROOT = iphoneos;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 3.0;
@@ -450,6 +445,7 @@
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
+				PRODUCT_MODULE_NAME = "$(PRODUCT_NAME:c99extidentifier)";
 				SDKROOT = iphoneos;
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
 				SWIFT_VERSION = 3.0;
@@ -474,6 +470,7 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.infinum.PrinceOfVersions;
+				PRODUCT_MODULE_NAME = "$(PRODUCT_NAME:c99extidentifier)";
 				PRODUCT_NAME = PrinceOfVersions;
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
@@ -495,6 +492,7 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.infinum.PrinceOfVersions;
+				PRODUCT_MODULE_NAME = "$(PRODUCT_NAME:c99extidentifier)";
 				PRODUCT_NAME = PrinceOfVersions;
 				SKIP_INSTALL = YES;
 				SWIFT_VERSION = 3.0;
@@ -509,6 +507,7 @@
 				INFOPLIST_FILE = VersionerTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.infinum.PrinceOfVersions;
+				PRODUCT_MODULE_NAME = "$(PRODUCT_NAME:c99extidentifier)Tests";
 				PRODUCT_NAME = PrinceOfVersions;
 				SWIFT_VERSION = 3.0;
 			};
@@ -522,6 +521,7 @@
 				INFOPLIST_FILE = VersionerTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.infinum.PrinceOfVersions;
+				PRODUCT_MODULE_NAME = "$(PRODUCT_NAME:c99extidentifier)Tests";
 				PRODUCT_NAME = PrinceOfVersions;
 				SWIFT_VERSION = 3.0;
 			};

--- a/Versioner/NotificationType.swift
+++ b/Versioner/NotificationType.swift
@@ -1,0 +1,14 @@
+//
+//  NotificationType.swift
+//  PrinceOfVersions
+//
+//  Created by Vedran Burojevic on 19/05/2017.
+//  Copyright © 2017 Infinum Ltd. All rights reserved.
+//
+
+import Foundation
+
+@objc public enum NotificationType: Int {
+    case always = 0
+    case once = 1
+}

--- a/Versioner/PrinceOfVersions.swift
+++ b/Versioner/PrinceOfVersions.swift
@@ -8,32 +8,12 @@
 
 import UIKit
 
+public typealias CompletionBlock = (UpdateInfoResponse) -> Void
+public typealias NewVersionBlock = (Version, Bool, [String: Any]?) -> Void
+public typealias NoNewVersionBlock = (Bool, [String: Any]?) -> Void
+public typealias ErrorBlock = (Error) -> Void
+
 public class PrinceOfVersions: NSObject {
-
-    public enum Result {
-        case success(UpdateInfo)
-        case failure(Error)
-    }
-
-    public class UpdateInfoResponse: NSObject {
-        /// The server's response to the URL request.
-        public let response: URLResponse?
-
-        /// The result of response serialization.
-        public let result: Result
-        
-        /// Init
-        init(response: URLResponse?, result: Result) {
-            self.response = response
-            self.result = result
-        }
-    }
-
-    public typealias CompletionBlock = (UpdateInfoResponse) -> Void
-    public typealias NewVersionBlock = (Version, Bool, [String: Any]?) -> Void
-    public typealias NoNewVersionBlock = (Bool, [String: Any]?) -> Void
-    public typealias ErrorBlock = (Error) -> Void
-    
     /**
      Check mimum required version, current installed version on device and current available version of the app with data stored on URL.
      It also checks if minimum version is satisfied and what should be frequency of notifying user.

--- a/Versioner/PrinceOfVersions.swift
+++ b/Versioner/PrinceOfVersions.swift
@@ -8,29 +8,32 @@
 
 import UIKit
 
-public struct PrinceOfVersions {
+public class PrinceOfVersions: NSObject {
 
     public enum Result {
         case success(UpdateInfo)
         case failure(Error)
     }
 
-    public struct UpdateInfoResponse {
-
+    public class UpdateInfoResponse: NSObject {
         /// The server's response to the URL request.
         public let response: URLResponse?
 
         /// The result of response serialization.
         public let result: Result
+        
+        /// Init
+        init(response: URLResponse?, result: Result) {
+            self.response = response
+            self.result = result
+        }
     }
 
     public typealias CompletionBlock = (UpdateInfoResponse) -> Void
     public typealias NewVersionBlock = (Version, Bool, [String: Any]?) -> Void
     public typealias NoNewVersionBlock = (Bool, [String: Any]?) -> Void
     public typealias ErrorBlock = (Error) -> Void
-
-    public init(){}
-
+    
     /**
      Check mimum required version, current installed version on device and current available version of the app with data stored on URL.
      It also checks if minimum version is satisfied and what should be frequency of notifying user.

--- a/Versioner/Result.swift
+++ b/Versioner/Result.swift
@@ -1,0 +1,14 @@
+//
+//  Result.swift
+//  PrinceOfVersions
+//
+//  Created by Vedran Burojevic on 19/05/2017.
+//  Copyright © 2017 Infinum Ltd. All rights reserved.
+//
+
+import Foundation
+
+public enum Result {
+    case success(UpdateInfo)
+    case failure(Error)
+}

--- a/Versioner/Result.swift
+++ b/Versioner/Result.swift
@@ -9,8 +9,8 @@
 import Foundation
 
 public class Result: NSObject {
-    let updateInfo: UpdateInfo?
-    let error: Error?
+    public let updateInfo: UpdateInfo?
+    public let error: Error?
     
     public init(updateInfo: UpdateInfo?, error: Error?) {
         self.updateInfo = updateInfo

--- a/Versioner/Result.swift
+++ b/Versioner/Result.swift
@@ -8,7 +8,12 @@
 
 import Foundation
 
-public enum Result {
-    case success(UpdateInfo)
-    case failure(Error)
+public class Result: NSObject {
+    let updateInfo: UpdateInfo?
+    let error: Error?
+    
+    public init(updateInfo: UpdateInfo?, error: Error?) {
+        self.updateInfo = updateInfo
+        self.error = error
+    }
 }

--- a/Versioner/UpdateInfo.swift
+++ b/Versioner/UpdateInfo.swift
@@ -14,7 +14,7 @@ enum UpdateInfoError: Error {
     case invalidCurrentVersion
 }
 
-public struct UpdateInfo {
+public class UpdateInfo: NSObject {
 
     public enum NotificationType : String {
         case always = "ALWAYS"

--- a/Versioner/UpdateInfo.swift
+++ b/Versioner/UpdateInfo.swift
@@ -15,12 +15,6 @@ enum UpdateInfoError: Error {
 }
 
 public class UpdateInfo: NSObject {
-
-    public enum NotificationType : String {
-        case always = "ALWAYS"
-        case once = "ONCE"
-    }
-
     /**
      Returns minimum required version of the app.
      */
@@ -32,7 +26,7 @@ public class UpdateInfo: NSObject {
      - Once: Show notification only once
      - Always: Show notification every time app run
      
-     Default value is @c .once
+     Default value is .once
      */
     public private(set) var notificationType: NotificationType = .once
 
@@ -85,9 +79,9 @@ public class UpdateInfo: NSObject {
             throw UpdateInfoError.invalidLatestVersion
         }
 
-        let notificationTypeString = (latestVersionInfo["notification_type"] as? String) ?? ""
+        let notificationTypeNumber = (latestVersionInfo["notification_type"] as? Int) ?? 0
 
-        if let _notificationType = NotificationType(rawValue: notificationTypeString) {
+        if let _notificationType = NotificationType(rawValue: notificationTypeNumber) {
             notificationType = _notificationType
         }
 

--- a/Versioner/UpdateInfo.swift
+++ b/Versioner/UpdateInfo.swift
@@ -79,11 +79,8 @@ public class UpdateInfo: NSObject {
             throw UpdateInfoError.invalidLatestVersion
         }
 
-        let notificationTypeNumber = (latestVersionInfo["notification_type"] as? Int) ?? 0
-
-        if let _notificationType = NotificationType(rawValue: notificationTypeNumber) {
-            notificationType = _notificationType
-        }
+        let notificationTypeString = (latestVersionInfo["notification_type"] as? String) ?? "ONCE"
+        notificationType = (notificationTypeString == "ONCE") ? .once : .always
 
         if let versionString = latestVersionInfo["version"] as? String {
             latestVersion = try Version(string: versionString)

--- a/Versioner/UpdateInfoResponse.swift
+++ b/Versioner/UpdateInfoResponse.swift
@@ -1,0 +1,23 @@
+//
+//  UpdateInfoResponse.swift
+//  PrinceOfVersions
+//
+//  Created by Vedran Burojevic on 19/05/2017.
+//  Copyright © 2017 Infinum Ltd. All rights reserved.
+//
+
+import Foundation
+
+public class UpdateInfoResponse: NSObject {
+    /// The server's response to the URL request.
+    public let response: URLResponse?
+    
+    /// The result of response serialization.
+    public let result: Result
+    
+    /// Init
+    init(response: URLResponse?, result: Result) {
+        self.response = response
+        self.result = result
+    }
+}

--- a/Versioner/Version.swift
+++ b/Versioner/Version.swift
@@ -13,7 +13,7 @@ public enum VersionError: Error {
     case invalidMajorVersion
 }
 
-public struct Version {
+public class Version: NSObject {
     public var major: Int
     public var minor: Int
     public var patch: Int
@@ -62,13 +62,11 @@ public struct Version {
         }
         return Int(components[index])
     }
-
-}
-
-extension Version: CustomStringConvertible {
-    public var description: String {
+    
+    override public var description: String {
         return "\(major).\(minor).\(patch)-\(build)"
     }
+
 }
 
 extension Version: Comparable {

--- a/Versioner/Version.swift
+++ b/Versioner/Version.swift
@@ -69,23 +69,23 @@ public class Version: NSObject {
     
     // MARK: - Comparison -
     
-    public func greaterThan(_ version: Version) -> Bool {
+    public func isGreaterThan(_ version: Version) -> Bool {
         return self > version
     }
     
-    public func greaterOrEqualTo(_ version: Version) -> Bool {
+    public func isGreaterOrEqualTo(_ version: Version) -> Bool {
         return self >= version
     }
     
-    public func lowerOrEqualTo(_ version: Version) -> Bool {
+    public func isLowerOrEqualTo(_ version: Version) -> Bool {
         return self <= version
     }
     
-    public func equalTo(_ version: Version) -> Bool {
+    public func isEqualTo(_ version: Version) -> Bool {
         return self == version
     }
     
-    public func notEqualTo(_ version: Version) -> Bool {
+    public func isNotEqualTo(_ version: Version) -> Bool {
         return self != version
     }
 

--- a/Versioner/Version.swift
+++ b/Versioner/Version.swift
@@ -66,6 +66,28 @@ public class Version: NSObject {
     override public var description: String {
         return "\(major).\(minor).\(patch)-\(build)"
     }
+    
+    // MARK: - Comparison -
+    
+    public func greaterThan(_ version: Version) -> Bool {
+        return self > version
+    }
+    
+    public func greaterOrEqualTo(_ version: Version) -> Bool {
+        return self >= version
+    }
+    
+    public func lowerOrEqualTo(_ version: Version) -> Bool {
+        return self <= version
+    }
+    
+    public func equalTo(_ version: Version) -> Bool {
+        return self == version
+    }
+    
+    public func notEqualTo(_ version: Version) -> Bool {
+        return self != version
+    }
 
 }
 

--- a/VersionerTests/UpdateInfoTest.swift
+++ b/VersionerTests/UpdateInfoTest.swift
@@ -7,6 +7,7 @@
 //
 
 import XCTest
+@testable import PrinceOfVersions
 
 class UpdateInfoTest: XCTestCase {
     


### PR DESCRIPTION
Problem je sto ne mozemo koristiti ovaj lib na nasim Objective-C projektima. Prebacio sam strukture u NSObject, morao sam i prebaciti neke klase u zasebne fileove, i prebaciti enume u primitivne tipove bez associated values i po potrebi napraviti klasu do njih kao Result.

Zbog ovih promjena ce se morati promijeniti malo implementacija u Swift projektima u koijma se vec koristi ovaj lib (npr. notification type se vis ene inicijalizira sa stringom, i result se ne moze switchati jer je sada objekt sa dva optionala). Jos nisam testirao u Swift projektu, samo u Oxxiu koji je Obj-C, prov sam htio cuti vase misljenje o ovome sve. Ako imate bolju ideju kako izvesti interoperability let me know. Mozemo mozda drzati ovaj branch kao zaseban za Obj-C i ne mergati u master, ali onda moramo drzati ovaj branch up to date ako bude promjena na masteru.