### PR TITLE
Fix parameter name

### DIFF
--- a/PrinceOfVersionsSample/PrinceOfVersionsIosSample/ObjectiveC Implementation/ConfigurationViewController/ObjCConfigurationViewController.m
+++ b/PrinceOfVersionsSample/PrinceOfVersionsIosSample/ObjectiveC Implementation/ConfigurationViewController/ObjCConfigurationViewController.m
@@ -87,7 +87,7 @@
     }];
 }
 
-- (void)fillUIWithInfoResponse:(__ObjcUpdateResultObject *)infoResponse
+- (void)fillUIWithInfoResponse:(UpdateResult *)infoResponse
 {
     self.updateVersionLabel.text = infoResponse.updateVersion.description;
     self.updateStateLabel.text = [self updateStateFromResult:infoResponse.updateState];


### PR DESCRIPTION
I've fixed the wrong parameter name in the ObjC sample project which caused the sample app not to be able to build.

