### PR TITLE
Add privacy manifest

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.1
+// swift-tools-version:5.3
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
@@ -17,7 +17,14 @@ let package = Package(
         )
     ],
     targets: [
-        .target(name: "PrinceOfVersions", dependencies: []),
-        .testTarget(name: "PrinceOfVersionsTests", dependencies: ["PrinceOfVersions"])
+        .target(
+            name: "PrinceOfVersions",
+            dependencies: [],
+            resources: [.copy("SupportingFiles/PrivacyInfo.xcprivacy")]
+        ),
+        .testTarget(
+            name: "PrinceOfVersionsTests",
+            dependencies: ["PrinceOfVersions"]
+        )
     ]
 )

--- a/PrinceOfVersions.podspec
+++ b/PrinceOfVersions.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name = "PrinceOfVersions"
-  s.version = "4.0.3"
+  s.version = "4.0.4"
   s.summary = "Library checks for updates using configuration from some resource."
   s.homepage = "https://github.com/infinum/ios-prince-of-versions"
   s.license = { :type => "MIT", :file => "LICENSE" }
@@ -9,7 +9,8 @@ Pod::Spec.new do |s|
   s.ios.deployment_target = '11.0'
   s.osx.deployment_target = '10.13'
   s.source = { :git => "https://github.com/infinum/ios-prince-of-versions.git", :tag => "#{s.version}" }
-  s.source_files  = "Sources/**/*.{h,m,swift}"
+  s.source_files = "Sources/**/*.{h,m,swift}"
+  s.resource_bundles = { 'PrinceOfVersions' => ['Sources/PrinceOfVersions/SupportingFiles/PrivacyInfo.xcprivacy'] }
   s.ios.framework  = 'UIKit'
   s.osx.framework  = 'AppKit'
   s.swift_version = "5.1"

--- a/PrinceOfVersions.xcodeproj/project.pbxproj
+++ b/PrinceOfVersions.xcodeproj/project.pbxproj
@@ -39,6 +39,7 @@
 		A8F359C224811A7000602DFB /* valid_update_only_v2_ios.json in Resources */ = {isa = PBXBuildFile; fileRef = A8F359C024811A3500602DFB /* valid_update_only_v2_ios.json */; };
 		A8F918A52449A8B60003C05E /* AnyDecodable.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8F918A42449A8B50003C05E /* AnyDecodable.swift */; };
 		A8F918AB2449A96F0003C05E /* ConfigurationData.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8F918A82449A96F0003C05E /* ConfigurationData.swift */; };
+		FA3C37BF2B613CAE00725950 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = FA3C37BC2B6138B900725950 /* PrivacyInfo.xcprivacy */; };
 		OBJ_45 /* AppStoreUpdateInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_9 /* AppStoreUpdateInfo.swift */; };
 		OBJ_46 /* AppStoreUpdateResultObjectiveC.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_11 /* AppStoreUpdateResultObjectiveC.swift */; };
 		OBJ_47 /* CheckUpdateFromAppStoreObjectiveCExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_13 /* CheckUpdateFromAppStoreObjectiveCExtensions.swift */; };
@@ -101,6 +102,7 @@
 		A8F359C024811A3500602DFB /* valid_update_only_v2_ios.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = valid_update_only_v2_ios.json; sourceTree = "<group>"; };
 		A8F918A42449A8B50003C05E /* AnyDecodable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AnyDecodable.swift; sourceTree = "<group>"; };
 		A8F918A82449A96F0003C05E /* ConfigurationData.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ConfigurationData.swift; sourceTree = "<group>"; };
+		FA3C37BC2B6138B900725950 /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
 		OBJ_11 /* AppStoreUpdateResultObjectiveC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppStoreUpdateResultObjectiveC.swift; sourceTree = "<group>"; };
 		OBJ_13 /* CheckUpdateFromAppStoreObjectiveCExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CheckUpdateFromAppStoreObjectiveCExtensions.swift; sourceTree = "<group>"; };
 		OBJ_14 /* CheckUpdatesObjectiveCExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CheckUpdatesObjectiveCExtensions.swift; sourceTree = "<group>"; };
@@ -193,6 +195,7 @@
 			children = (
 				06F8AE03241A57590099E820 /* PrinceOfVersions.h */,
 				06F8ADB1241945D90099E820 /* Info.plist */,
+				FA3C37BC2B6138B900725950 /* PrivacyInfo.xcprivacy */,
 			);
 			path = SupportingFiles;
 			sourceTree = "<group>";
@@ -470,6 +473,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				FA3C37BF2B613CAE00725950 /* PrivacyInfo.xcprivacy in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Sources/PrinceOfVersions/SupportingFiles/PrivacyInfo.xcprivacy
+++ b/Sources/PrinceOfVersions/SupportingFiles/PrivacyInfo.xcprivacy
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array/>
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array>
+		<dict>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array>
+				<string>CA92.1</string>
+			</array>
+			<key>NSPrivacyAccessedAPIType</key>
+			<string>User Defaults</string>
+		</dict>
+	</array>
+</dict>
+</plist>


### PR DESCRIPTION
This PR adds privacy manifest that Apple will require from this spring.

I've tested CP and SPM integration and they both worked for me. Additionally, I had to update swift-tools version to 5.3 as `resources` can only be declared from that version

[This section](https://developer.apple.com/documentation/bundleresources/privacy_manifest_files/describing_use_of_required_reason_api?language=objc) describes type reasons. It seems to me that only CA92.1 is relevant for this library, but I would like if someone could double check this.