### PR TITLE
Feature/cache policy

### DIFF
--- a/PrinceOfVersionsMacSample/PrinceOfVersionsMacSample/Swift Implementation/ConfigurationController.swift
+++ b/PrinceOfVersionsMacSample/PrinceOfVersionsMacSample/Swift Implementation/ConfigurationController.swift
@@ -59,7 +59,6 @@ private extension ConfigurationController {
         PrinceOfVersions.checkForUpdates(
             from: princeOfVersionsURL,
             options: options,
-            cachePolicy: .reloadIgnoringLocalAndRemoteCacheData,
             completion: { [weak self] response in
                 switch response.result {
                 case .success(let updateResultData):
@@ -81,7 +80,6 @@ private extension ConfigurationController {
         // of the app is not available on the App Store
         PrinceOfVersions.checkForUpdateFromAppStore(
             trackPhaseRelease: false,
-            cachePolicy: .reloadIgnoringLocalAndRemoteCacheData,
             completion: { result in
                 switch result {
                 case .success:

--- a/PrinceOfVersionsMacSample/PrinceOfVersionsMacSample/Swift Implementation/ConfigurationController.swift
+++ b/PrinceOfVersionsMacSample/PrinceOfVersionsMacSample/Swift Implementation/ConfigurationController.swift
@@ -59,7 +59,7 @@ private extension ConfigurationController {
         PrinceOfVersions.checkForUpdates(
             from: princeOfVersionsURL,
             options: options,
-            cachePolicy: .reloadIgnoringLocalCacheData,
+            cachePolicy: .reloadIgnoringLocalAndRemoteCacheData,
             completion: { [weak self] response in
                 switch response.result {
                 case .success(let updateResultData):
@@ -81,7 +81,7 @@ private extension ConfigurationController {
         // of the app is not available on the App Store
         PrinceOfVersions.checkForUpdateFromAppStore(
             trackPhaseRelease: false,
-            cachePolicy: .reloadIgnoringLocalCacheData,
+            cachePolicy: .reloadIgnoringLocalAndRemoteCacheData,
             completion: { result in
                 switch result {
                 case .success:

--- a/PrinceOfVersionsMacSample/PrinceOfVersionsMacSample/Swift Implementation/ConfigurationController.swift
+++ b/PrinceOfVersionsMacSample/PrinceOfVersionsMacSample/Swift Implementation/ConfigurationController.swift
@@ -56,15 +56,20 @@ private extension ConfigurationController {
 
         let princeOfVersionsURL = URL(string: Constants.princeOfVersionsURL)!
 
-        PrinceOfVersions.checkForUpdates(from: princeOfVersionsURL, options: options, completion: { [weak self] response in
-            switch response.result {
-            case .success(let updateResultData):
-                self?.fillUI(with: updateResultData)
-            case .failure:
-                // Handle error
-                break
+        PrinceOfVersions.checkForUpdates(
+            from: princeOfVersionsURL,
+            options: options,
+            cachePolicy: .reloadIgnoringLocalCacheData,
+            completion: { [weak self] response in
+                switch response.result {
+                case .success(let updateResultData):
+                    self?.fillUI(with: updateResultData)
+                case .failure:
+                    // Handle error
+                    break
+                }
             }
-        })
+        )
 
     }
 
@@ -76,6 +81,7 @@ private extension ConfigurationController {
         // of the app is not available on the App Store
         PrinceOfVersions.checkForUpdateFromAppStore(
             trackPhaseRelease: false,
+            cachePolicy: .reloadIgnoringLocalCacheData,
             completion: { result in
                 switch result {
                 case .success:

--- a/PrinceOfVersionsSample/PrinceOfVersionsIosSample/Swift Implementation/ConfigurationViewController.swift
+++ b/PrinceOfVersionsSample/PrinceOfVersionsIosSample/Swift Implementation/ConfigurationViewController.swift
@@ -61,7 +61,7 @@ private extension ConfigurationViewController {
         PrinceOfVersions.checkForUpdates(
             from: princeOfVersionsURL,
             options: options,
-            cachePolicy: .reloadIgnoringLocalCacheData,
+            cachePolicy: .reloadIgnoringLocalAndRemoteCacheData,
             completion: { [weak self] response in
                 switch response.result {
                 case .success(let infoResponse):
@@ -78,7 +78,7 @@ private extension ConfigurationViewController {
         // of the app is not available on the App Store
         PrinceOfVersions.checkForUpdateFromAppStore(
             trackPhaseRelease: false,
-            cachePolicy: .reloadIgnoringLocalCacheData,
+            cachePolicy: .reloadIgnoringLocalAndRemoteCacheData,
             completion: { result in
                 switch result {
                 case .success:

--- a/PrinceOfVersionsSample/PrinceOfVersionsIosSample/Swift Implementation/ConfigurationViewController.swift
+++ b/PrinceOfVersionsSample/PrinceOfVersionsIosSample/Swift Implementation/ConfigurationViewController.swift
@@ -61,7 +61,6 @@ private extension ConfigurationViewController {
         PrinceOfVersions.checkForUpdates(
             from: princeOfVersionsURL,
             options: options,
-            cachePolicy: .reloadIgnoringLocalAndRemoteCacheData,
             completion: { [weak self] response in
                 switch response.result {
                 case .success(let infoResponse):
@@ -78,7 +77,6 @@ private extension ConfigurationViewController {
         // of the app is not available on the App Store
         PrinceOfVersions.checkForUpdateFromAppStore(
             trackPhaseRelease: false,
-            cachePolicy: .reloadIgnoringLocalAndRemoteCacheData,
             completion: { result in
                 switch result {
                 case .success:

--- a/PrinceOfVersionsSample/PrinceOfVersionsIosSample/Swift Implementation/ConfigurationViewController.swift
+++ b/PrinceOfVersionsSample/PrinceOfVersionsIosSample/Swift Implementation/ConfigurationViewController.swift
@@ -61,6 +61,7 @@ private extension ConfigurationViewController {
         PrinceOfVersions.checkForUpdates(
             from: princeOfVersionsURL,
             options: options,
+            cachePolicy: .reloadIgnoringLocalCacheData,
             completion: { [weak self] response in
                 switch response.result {
                 case .success(let infoResponse):
@@ -77,6 +78,7 @@ private extension ConfigurationViewController {
         // of the app is not available on the App Store
         PrinceOfVersions.checkForUpdateFromAppStore(
             trackPhaseRelease: false,
+            cachePolicy: .reloadIgnoringLocalCacheData,
             completion: { result in
                 switch result {
                 case .success:
@@ -119,6 +121,7 @@ private extension UpdateStatus {
         case .noUpdateAvailable: return "No Update Available"
         case .requiredUpdateNeeded: return "Required Update Needed"
         case .newUpdateAvailable: return "New Update Available"
+        @unknown default: return "Unkown state"
         }
     }
 }

--- a/README.md
+++ b/README.md
@@ -87,7 +87,6 @@ For JSON file details and formatting, read [JSON specification](JSON.md).
 
     PrinceOfVersions.checkForUpdates(
         from: princeOfVersionsURL,
-        cachePolicy: .reloadIgnoringLocalAndRemoteCacheData,
         completion: { [unowned self] response in
             switch response.result {
             case .success(let updateResultData):
@@ -106,7 +105,7 @@ For JSON file details and formatting, read [JSON specification](JSON.md).
 
 When checking for updates, be it for AppStore or other sources, you can provide a *cachePolicy* parameter. The *cachePolicy* parameter determines which request cache policy will be used for network requests.
 
-The initial value for the default `URLSession` configuration uses **.useProtocolCachePolicy** which shouldn't be the default behavior for Prince of Versions, we want to refresh the data from the server every time. That's why we defaulted the value to **.reloadIgnoringLocalAndRemoteCacheData**. If you want to change the default behavior, you can always provide which cache policy you want to use, as seen in the example above :)
+The initial value for the default `URLSession` configuration uses **.useProtocolCachePolicy**, which shouldn't be the default behavior for Prince of Versions; we want to refresh the data from the server every time. That's why we defaulted the value to **.reloadIgnoringLocalCacheData**. If you want to change the default behavior, you can always provide a different cache policy that suits your needs.
 
 #### Adding-requirements
 

--- a/README.md
+++ b/README.md
@@ -105,7 +105,8 @@ For JSON file details and formatting, read [JSON specification](JSON.md).
 #### Request cache policy
 
 When checking for updates, be it for AppStore or other sources, you can provide a *cachePolicy* parameter. The *cachePolicy* parameter determines which request cache policy will be used for network requests.
-The initial value for the default `URLSession` configuration is **.useProtocolCachePolicy** which shouldn't be the default behavior for Prince of Versions, we want to refresh the data from the server every time. That's why we defaulted the value to **.reloadIgnoringLocalCacheData**. If you want to change the default behavior, you can always provide which cache policy you want to use, as seen in the example above :)
+
+The initial value for the default `URLSession` configuration uses **.useProtocolCachePolicy** which shouldn't be the default behavior for Prince of Versions, we want to refresh the data from the server every time. That's why we defaulted the value to **.reloadIgnoringLocalCacheData**. If you want to change the default behavior, you can always provide which cache policy you want to use, as seen in the example above :)
 
 #### Adding-requirements
 

--- a/README.md
+++ b/README.md
@@ -83,20 +83,29 @@ For JSON file details and formatting, read [JSON specification](JSON.md).
 #### Getting all data
 
   ```swift
-  let princeOfVersionsURL = URL(string: "https://pastebin.com/raw/0MfYmWGu")!
+    let princeOfVersionsURL = URL(string: "https://pastebin.com/raw/0MfYmWGu")!
 
-  PrinceOfVersions.checkForUpdates(from: princeOfVersionsURL, completion: { [unowned self] response in
-      switch response.result {
-      case .success(let updateResultData):
-          print("Update version: \(updateResultData.updateVersion)")
-          print("Installed version: \(updateResultData.updateInfo.installedVersion)")
-          print("Update status: \(updateResultData.updateStatus)")
-      case .failure:
-          // Handle error
-          break
-      }
-  })
+    PrinceOfVersions.checkForUpdates(
+        from: princeOfVersionsURL,
+        cachePolicy: .reloadIgnoringLocalCacheData,
+        completion: { [unowned self] response in
+            switch response.result {
+            case .success(let updateResultData):
+                print("Update version: \(updateResultData.updateVersion)")
+                print("Installed version: \(updateResultData.updateInfo.installedVersion)")
+                print("Update status: \(updateResultData.updateStatus)")
+            case .failure:
+                // Handle error
+                break
+            }
+        }
+    )
   ```
+  
+#### Request cache policy
+
+When checking for updates, be it for AppStore or other sources, you can provide a *cachePolicy* parameter. The *cachePolicy* parameter determines which request cache policy will be used for network requests.
+The initial value for the default `URLSession` configuration is **.useProtocolCachePolicy** which shouldn't be the default behavior for Prince of Versions, we want to refresh the data from the server every time. That's why we defaulted the value to **.reloadIgnoringLocalCacheData**. If you want to change the default behavior, you can always provide which cache policy you want to use, as seen in the example above :)
 
 #### Adding-requirements
 

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ For JSON file details and formatting, read [JSON specification](JSON.md).
 
     PrinceOfVersions.checkForUpdates(
         from: princeOfVersionsURL,
-        cachePolicy: .reloadIgnoringLocalCacheData,
+        cachePolicy: .reloadIgnoringLocalAndRemoteCacheData,
         completion: { [unowned self] response in
             switch response.result {
             case .success(let updateResultData):
@@ -106,7 +106,7 @@ For JSON file details and formatting, read [JSON specification](JSON.md).
 
 When checking for updates, be it for AppStore or other sources, you can provide a *cachePolicy* parameter. The *cachePolicy* parameter determines which request cache policy will be used for network requests.
 
-The initial value for the default `URLSession` configuration uses **.useProtocolCachePolicy** which shouldn't be the default behavior for Prince of Versions, we want to refresh the data from the server every time. That's why we defaulted the value to **.reloadIgnoringLocalCacheData**. If you want to change the default behavior, you can always provide which cache policy you want to use, as seen in the example above :)
+The initial value for the default `URLSession` configuration uses **.useProtocolCachePolicy** which shouldn't be the default behavior for Prince of Versions, we want to refresh the data from the server every time. That's why we defaulted the value to **.reloadIgnoringLocalAndRemoteCacheData**. If you want to change the default behavior, you can always provide which cache policy you want to use, as seen in the example above :)
 
 #### Adding-requirements
 

--- a/Sources/PrinceOfVersions/PrinceOfVersions.swift
+++ b/Sources/PrinceOfVersions/PrinceOfVersions.swift
@@ -34,7 +34,7 @@ public extension PrinceOfVersions {
      - parameter URL: URL that containts configuration data.
      - parameter callbackQueue: The queue on which the completion handler is dispatched. By default, `main` queue is used.
      - parameter options: Used for additional configuration such as `shouldPinCertificates`, `httpHeaderFields` and `userRequirements`
-     - parameter cachePolicy: Determines which URLRequest cache policy should be used. Defaults to `.reloadIgnoringLocalAndRemoteCacheData` which will call the API every time.
+     - parameter cachePolicy: Determines which URLRequest cache policy should be used. Defaults to `.reloadIgnoringLocalCacheData` which will call the API every time.
      - parameter completion: The completion handler to call when the load request is complete. It returns result that contains UpdateResult data or PoVError error
 
      - returns: Discardable `URLSessionDataTask`
@@ -44,7 +44,7 @@ public extension PrinceOfVersions {
         from URL: URL,
         callbackQueue: DispatchQueue = .main,
         options: PoVRequestOptions = PoVRequestOptions(),
-        cachePolicy: NSURLRequest.CachePolicy = .reloadIgnoringLocalAndRemoteCacheData,
+        cachePolicy: NSURLRequest.CachePolicy = .reloadIgnoringLocalCacheData,
         completion: @escaping CompletionBlock
     ) -> URLSessionDataTask {
 
@@ -115,7 +115,7 @@ public extension PrinceOfVersions {
      - parameter bundle: Bundle where .plist file is stored in which app identifier and app versions should be checked.
      - parameter callbackQueue: The queue on which the completion handler is dispatched. By default, `main` queue is used.
      - parameter notificationFrequency: Determines update status appearance frequency.
-     - parameter cachePolicy: Determines which URLRequest cache policy should be used. Defaults to `.reloadIgnoringLocalAndRemoteCacheData` which will call the API every time.
+     - parameter cachePolicy: Determines which URLRequest cache policy should be used. Defaults to `.reloadIgnoringLocalCacheData` which will call the API every time.
      - parameter completion: The completion handler to call when the load request is complete. It returns result that contains UpdatInfo data or PoVError error.
 
      - returns: Discardable `URLSessionDataTask`
@@ -126,7 +126,7 @@ public extension PrinceOfVersions {
         bundle: Bundle = .main,
         callbackQueue: DispatchQueue = .main,
         notificationFrequency: NotificationType = .always,
-        cachePolicy: NSURLRequest.CachePolicy = .reloadIgnoringLocalAndRemoteCacheData,
+        cachePolicy: NSURLRequest.CachePolicy = .reloadIgnoringLocalCacheData,
         completion: @escaping AppStoreCompletionBlock
     ) -> URLSessionDataTask? {
 

--- a/Sources/PrinceOfVersions/PrinceOfVersions.swift
+++ b/Sources/PrinceOfVersions/PrinceOfVersions.swift
@@ -34,7 +34,7 @@ public extension PrinceOfVersions {
      - parameter URL: URL that containts configuration data.
      - parameter callbackQueue: The queue on which the completion handler is dispatched. By default, `main` queue is used.
      - parameter options: Used for additional configuration such as `shouldPinCertificates`, `httpHeaderFields` and `userRequirements`
-     - parameter cachePolicy: Determines which URLRequest cache policy should be used. Defaults to `.reloadIgnoringLocalCacheData` which will call the API every time.
+     - parameter cachePolicy: Determines which URLRequest cache policy should be used. Defaults to `.reloadIgnoringLocalAndRemoteCacheData` which will call the API every time.
      - parameter completion: The completion handler to call when the load request is complete. It returns result that contains UpdateResult data or PoVError error
 
      - returns: Discardable `URLSessionDataTask`
@@ -44,7 +44,7 @@ public extension PrinceOfVersions {
         from URL: URL,
         callbackQueue: DispatchQueue = .main,
         options: PoVRequestOptions = PoVRequestOptions(),
-        cachePolicy: NSURLRequest.CachePolicy = .reloadIgnoringLocalCacheData,
+        cachePolicy: NSURLRequest.CachePolicy = .reloadIgnoringLocalAndRemoteCacheData,
         completion: @escaping CompletionBlock
     ) -> URLSessionDataTask {
 
@@ -115,7 +115,7 @@ public extension PrinceOfVersions {
      - parameter bundle: Bundle where .plist file is stored in which app identifier and app versions should be checked.
      - parameter callbackQueue: The queue on which the completion handler is dispatched. By default, `main` queue is used.
      - parameter notificationFrequency: Determines update status appearance frequency.
-     - parameter cachePolicy: Determines which URLRequest cache policy should be used. Defaults to `.reloadIgnoringLocalCacheData` which will call the API every time.
+     - parameter cachePolicy: Determines which URLRequest cache policy should be used. Defaults to `.reloadIgnoringLocalAndRemoteCacheData` which will call the API every time.
      - parameter completion: The completion handler to call when the load request is complete. It returns result that contains UpdatInfo data or PoVError error.
 
      - returns: Discardable `URLSessionDataTask`
@@ -126,7 +126,7 @@ public extension PrinceOfVersions {
         bundle: Bundle = .main,
         callbackQueue: DispatchQueue = .main,
         notificationFrequency: NotificationType = .always,
-        cachePolicy: NSURLRequest.CachePolicy = .reloadIgnoringLocalCacheData,
+        cachePolicy: NSURLRequest.CachePolicy = .reloadIgnoringLocalAndRemoteCacheData,
         completion: @escaping AppStoreCompletionBlock
     ) -> URLSessionDataTask? {
 

--- a/Sources/PrinceOfVersions/PrinceOfVersions.swift
+++ b/Sources/PrinceOfVersions/PrinceOfVersions.swift
@@ -34,6 +34,7 @@ public extension PrinceOfVersions {
      - parameter URL: URL that containts configuration data.
      - parameter callbackQueue: The queue on which the completion handler is dispatched. By default, `main` queue is used.
      - parameter options: Used for additional configuration such as `shouldPinCertificates`, `httpHeaderFields` and `userRequirements`
+     - parameter cachePolicy: Determines which URLRequest cache policy should be used. Defaults to `.reloadIgnoringLocalCacheData` which will call the API every time.
      - parameter completion: The completion handler to call when the load request is complete. It returns result that contains UpdateResult data or PoVError error
 
      - returns: Discardable `URLSessionDataTask`
@@ -43,13 +44,17 @@ public extension PrinceOfVersions {
         from URL: URL,
         callbackQueue: DispatchQueue = .main,
         options: PoVRequestOptions = PoVRequestOptions(),
+        cachePolicy: NSURLRequest.CachePolicy = .reloadIgnoringLocalCacheData,
         completion: @escaping CompletionBlock
     ) -> URLSessionDataTask {
 
         let princeOfVersions = PrinceOfVersions()
         princeOfVersions.shouldPinCertificates = options.shouldPinCertificates
 
-        let defaultSession = URLSession(configuration: URLSessionConfiguration.default, delegate: princeOfVersions, delegateQueue: nil)
+        let configuration = URLSessionConfiguration.default
+        configuration.requestCachePolicy = cachePolicy
+
+        let defaultSession = URLSession(configuration: configuration, delegate: princeOfVersions, delegateQueue: nil)
 
         let request = princeOfVersions.createRequest(for: URL, headerFields: options.httpHeaderFields)
 
@@ -110,6 +115,7 @@ public extension PrinceOfVersions {
      - parameter bundle: Bundle where .plist file is stored in which app identifier and app versions should be checked.
      - parameter callbackQueue: The queue on which the completion handler is dispatched. By default, `main` queue is used.
      - parameter notificationFrequency: Determines update status appearance frequency.
+     - parameter cachePolicy: Determines which URLRequest cache policy should be used. Defaults to `.reloadIgnoringLocalCacheData` which will call the API every time.
      - parameter completion: The completion handler to call when the load request is complete. It returns result that contains UpdatInfo data or PoVError error.
 
      - returns: Discardable `URLSessionDataTask`
@@ -120,6 +126,7 @@ public extension PrinceOfVersions {
         bundle: Bundle = .main,
         callbackQueue: DispatchQueue = .main,
         notificationFrequency: NotificationType = .always,
+        cachePolicy: NSURLRequest.CachePolicy = .reloadIgnoringLocalCacheData,
         completion: @escaping AppStoreCompletionBlock
     ) -> URLSessionDataTask? {
 
@@ -139,6 +146,7 @@ public extension PrinceOfVersions {
             bundle: bundle,
             callbackQueue: callbackQueue,
             notificationFrequency: notificationFrequency,
+            cachePolicy: cachePolicy,
             completion: completion
         )
     }
@@ -156,12 +164,16 @@ internal extension PrinceOfVersions {
         callbackQueue: DispatchQueue = .main,
         notificationFrequency: NotificationType = .always,
         testMode: Bool = false,
+        cachePolicy: NSURLRequest.CachePolicy,
         completion: @escaping AppStoreCompletionBlock
     ) -> URLSessionDataTask? {
 
         let princeOfVersions = PrinceOfVersions()
 
-        let defaultSession = URLSession(configuration: URLSessionConfiguration.default, delegate: princeOfVersions, delegateQueue: nil)
+        let configuration = URLSessionConfiguration.default
+        configuration.requestCachePolicy = cachePolicy
+
+        let defaultSession = URLSession(configuration: configuration, delegate: princeOfVersions, delegateQueue: nil)
 
         guard !testMode else {
             callbackQueue.async {

--- a/Tests/PrinceOfVersionsTests/PrinceOfVersionsTest.swift
+++ b/Tests/PrinceOfVersionsTests/PrinceOfVersionsTest.swift
@@ -51,7 +51,7 @@ class PrinceOfVersionsTest: XCTestCase {
                 trackPhaseRelease: false,
                 bundle: bundle,
                 testMode: true,
-                cachePolicy: .reloadIgnoringLocalAndRemoteCacheData,
+                cachePolicy: .reloadIgnoringLocalCacheData,
                 completion: { result in
                     switch result {
                     case .success(let updateResult):
@@ -88,7 +88,7 @@ class PrinceOfVersionsTest: XCTestCase {
                 trackPhaseRelease: true,
                 bundle: bundle,
                 testMode: true,
-                cachePolicy: .reloadIgnoringLocalAndRemoteCacheData,
+                cachePolicy: .reloadIgnoringLocalCacheData,
                 completion: { result in
                     switch result {
                     case .success(let info):

--- a/Tests/PrinceOfVersionsTests/PrinceOfVersionsTest.swift
+++ b/Tests/PrinceOfVersionsTests/PrinceOfVersionsTest.swift
@@ -46,29 +46,36 @@ class PrinceOfVersionsTest: XCTestCase {
         let minimumSdkForLatestVersion = try! Version(string: "12.0")
 
         runAsyncTest { finished in
-            PrinceOfVersions.internalyGetDataFromAppStore(URL(fileURLWithPath: jsonPath), trackPhaseRelease: false, bundle: bundle, testMode: true, completion: { result in
-                switch result {
-                case .success(let updateResult):
-                    XCTAssert(updateResult.updateInfo.installedVersion == installedVersion)
+            PrinceOfVersions.internalyGetDataFromAppStore(
+                URL(fileURLWithPath: jsonPath),
+                trackPhaseRelease: false,
+                bundle: bundle,
+                testMode: true,
+                cachePolicy: .reloadIgnoringLocalCacheData,
+                completion: { result in
+                    switch result {
+                    case .success(let updateResult):
+                        XCTAssert(updateResult.updateInfo.installedVersion == installedVersion)
 
-                    guard let latestVersion = updateResult.updateInfo.lastVersionAvailable else {
-                        XCTFail("Last version available should not be nil")
-                        return
-                    }
+                        guard let latestVersion = updateResult.updateInfo.lastVersionAvailable else {
+                            XCTFail("Last version available should not be nil")
+                            return
+                        }
 
-                    XCTAssert(latestVersion == lastVersionAvailable)
-                    if let minSdkForLatestVersion = updateResult.updateInfo.configurationData?.minimumOsVersion {
-                        XCTAssert(minSdkForLatestVersion == minimumSdkForLatestVersion)
-                    } else {
-                        XCTFail("min sdk should not be nil")
+                        XCTAssert(latestVersion == lastVersionAvailable)
+                        if let minSdkForLatestVersion = updateResult.updateInfo.configurationData?.minimumOsVersion {
+                            XCTAssert(minSdkForLatestVersion == minimumSdkForLatestVersion)
+                        } else {
+                            XCTFail("min sdk should not be nil")
+                        }
+                        XCTAssert(!updateResult.phaseReleaseInProgress)
+                        finished()
+                    case .failure:
+                        XCTFail("Invalid data")
+                        finished()
                     }
-                    XCTAssert(!updateResult.phaseReleaseInProgress)
-                    finished()
-                case .failure:
-                    XCTFail("Invalid data")
-                    finished()
                 }
-            })
+            )
         }
     }
 
@@ -76,16 +83,23 @@ class PrinceOfVersionsTest: XCTestCase {
         let bundle = Bundle(for: type(of: self))
         let jsonPath = bundle.path(forResource: "app_store_version_example", ofType: "json")!
         runAsyncTest { finished in
-            PrinceOfVersions.internalyGetDataFromAppStore(URL(fileURLWithPath: jsonPath), trackPhaseRelease: true, bundle: bundle, testMode: true, completion: { result in
-                switch result {
-                case .success(let info):
-                    XCTAssert(!info.phaseReleaseInProgress)
-                    finished()
-                case .failure:
-                    XCTFail("Invalid data")
-                    finished()
+            PrinceOfVersions.internalyGetDataFromAppStore(
+                URL(fileURLWithPath: jsonPath),
+                trackPhaseRelease: true,
+                bundle: bundle,
+                testMode: true,
+                cachePolicy: .reloadIgnoringLocalCacheData,
+                completion: { result in
+                    switch result {
+                    case .success(let info):
+                        XCTAssert(!info.phaseReleaseInProgress)
+                        finished()
+                    case .failure:
+                        XCTFail("Invalid data")
+                        finished()
+                    }
                 }
-            })
+            )
         }
     }
 }

--- a/Tests/PrinceOfVersionsTests/PrinceOfVersionsTest.swift
+++ b/Tests/PrinceOfVersionsTests/PrinceOfVersionsTest.swift
@@ -51,7 +51,7 @@ class PrinceOfVersionsTest: XCTestCase {
                 trackPhaseRelease: false,
                 bundle: bundle,
                 testMode: true,
-                cachePolicy: .reloadIgnoringLocalCacheData,
+                cachePolicy: .reloadIgnoringLocalAndRemoteCacheData,
                 completion: { result in
                     switch result {
                     case .success(let updateResult):
@@ -88,7 +88,7 @@ class PrinceOfVersionsTest: XCTestCase {
                 trackPhaseRelease: true,
                 bundle: bundle,
                 testMode: true,
-                cachePolicy: .reloadIgnoringLocalCacheData,
+                cachePolicy: .reloadIgnoringLocalAndRemoteCacheData,
                 completion: { result in
                     switch result {
                     case .success(let info):


### PR DESCRIPTION
It looks like caching caused some issues where we wouldn't show the update UI prompt. It makes sense not to have caching in PoV since we always want to use the latest results from the server.

- What's new:
- added `cachePolicy` parameter to `checkForUpdates` and `checkForAppStoreUpdates`
- defaulted the value to ignore the local and remote cache and always check the server
- updated the readme