### PR TITLE
Fix lookup API to return data based on the country

### DIFF
--- a/Sources/PrinceOfVersions/Objective-C Helpers/Objective-C Extensions/CheckUpdateFromAppStoreObjectiveCExtensions.swift
+++ b/Sources/PrinceOfVersions/Objective-C Helpers/Objective-C Extensions/CheckUpdateFromAppStoreObjectiveCExtensions.swift
@@ -88,30 +88,42 @@ extension PrinceOfVersions {
 
      If parameter `notificationFrequency` is set to `.always`  and latest version of the app is bigger than installed version, method will always return `.newUpdateAvailable`. However, if the`notificationFrequency` is set to `.once`, only first time this method is called for the same latest app version, it will return `.newUpdateAvailable`, each subsequent call, it will return `.noUpdateAvailable`.
 
+     If the optional `country` parameter is provided, the API request will target the specified App Store region (e.g., `"no"` for Norway). If `country` is not provided, the API will fallback to its default behavior, typically fetching data from the U.S. App Store.
+
      - Parameters:
         * bundle: Bundle where .plist file is stored in which app identifier and app versions should be checked.
         * trackPhaseRelease: Boolean that indicates whether PoV should notify about new version after 7 days when app is fully rolled out or immediately. Default value is `YES`.
         * callbackQueue: The queue on which the completion handler is dispatched. By default, `main` queue is used.
         * notificationFrequency: Determines update status appearance frequency.
+        * country: Optional parameter to specify the App Store region to target (e.g., `"no"` for Norway). Defaults to `nil`.
         * completion: The completion handler to call when the load request is complete. It returns result that contains UpdatInfo data or PoVError error
 
      - Returns:
         * Discardable `URLSessionDataTask`
      */
     @available(swift, obsoleted: 1.0)
-    @objc(checkForUpdateFromAppStoreWithTrackPhasedRelease:callbackQueue:bundle:notificationFrequency:completion:error:)
+    @objc(checkForUpdateFromAppStoreWithTrackPhasedRelease:callbackQueue:bundle:notificationFrequency:country:completion:error:)
     @discardableResult
     public static func checkForUpdateFromAppStore(
         trackPhaseRelease: Bool,
         callbackQueue: DispatchQueue,
         bundle: Bundle,
         notificationFrequency: UpdateNotificationType,
+        country: String?,
         completion: @escaping AppStoreObjectCompletionBlock,
         error: @escaping ObjectErrorBlock
     ) -> URLSessionDataTask? {
 
         let frequency: NotificationType = notificationFrequency == .always ? .always : .once
 
-        return internalyCheckAndPrepareForUpdateAppStore(bundle: bundle, trackPhaseRelease: trackPhaseRelease, callbackQueue: callbackQueue, notificationFrequency: frequency, completion: completion, error: error)
+        return internalyCheckAndPrepareForUpdateAppStore(
+            bundle: bundle,
+            trackPhaseRelease: trackPhaseRelease,
+            callbackQueue: callbackQueue,
+            notificationFrequency: frequency,
+            country: country,
+            completion: completion,
+            error: error
+        )
     }
 }

--- a/Sources/PrinceOfVersions/Objective-C Helpers/Objective-C Extensions/ObjectiveCBaseExtensions.swift
+++ b/Sources/PrinceOfVersions/Objective-C Helpers/Objective-C Extensions/ObjectiveCBaseExtensions.swift
@@ -61,16 +61,24 @@ internal extension PrinceOfVersions {
         trackPhaseRelease: Bool,
         callbackQueue: DispatchQueue,
         notificationFrequency: NotificationType = .always,
+        country: String? = nil,
         completion: @escaping AppStoreObjectCompletionBlock,
         error: @escaping ObjectErrorBlock
     ) -> URLSessionDataTask? {
-        return PrinceOfVersions.checkForUpdateFromAppStore(trackPhaseRelease: trackPhaseRelease, bundle: bundle, callbackQueue: callbackQueue, notificationFrequency: notificationFrequency, completion: { result in
+        return PrinceOfVersions.checkForUpdateFromAppStore(
+            trackPhaseRelease: trackPhaseRelease,
+            bundle: bundle,
+            callbackQueue: callbackQueue,
+            notificationFrequency: notificationFrequency,
+            country: country,
+            completion: {
+                result in
                 switch result {
                 case .success(let appStoreInfo):
                     completion(__ObjCAppStoreResult(from: appStoreInfo))
                 case .failure(let (errorResponse as NSError)):
                     error(errorResponse)
                 }
-        })
+            })
     }
 }

--- a/Sources/PrinceOfVersions/PrinceOfVersions.swift
+++ b/Sources/PrinceOfVersions/PrinceOfVersions.swift
@@ -111,11 +111,14 @@ public extension PrinceOfVersions {
 
      If parameter `notificationFrequency` is set to `.always`  and latest version of the app is bigger than installed version, method will always return `.newUpdateAvailable`. However, if the`notificationFrequency` is set to `.once`, only first time this method is called for the same latest app version, it will return `.newUpdateAvailable`, each subsequent call, it will return `.noUpdateAvailable`.
 
+     If the optional `country` parameter is provided, the API request will target the specified App Store region (e.g., `"no"` for Norway). If `country` is not provided, the API will fallback to its default behavior, typically fetching data from the U.S. App Store.
+
      - parameter trackPhaseRelease: Boolean that indicates whether PoV should notify about new version after 7 days when app is fully rolled out or immediately. Default value is `true`.
      - parameter bundle: Bundle where .plist file is stored in which app identifier and app versions should be checked.
      - parameter callbackQueue: The queue on which the completion handler is dispatched. By default, `main` queue is used.
      - parameter notificationFrequency: Determines update status appearance frequency.
      - parameter cachePolicy: Determines which URLRequest cache policy should be used. Defaults to `.reloadIgnoringLocalCacheData` which will call the API every time.
+     - parameter country: Optional parameter to specify the App Store region to target (e.g., `"no"` for Norway). Defaults to `nil`.
      - parameter completion: The completion handler to call when the load request is complete. It returns result that contains UpdatInfo data or PoVError error.
 
      - returns: Discardable `URLSessionDataTask`
@@ -127,13 +130,27 @@ public extension PrinceOfVersions {
         callbackQueue: DispatchQueue = .main,
         notificationFrequency: NotificationType = .always,
         cachePolicy: NSURLRequest.CachePolicy = .reloadIgnoringLocalCacheData,
+        country: String? = nil,
         completion: @escaping AppStoreCompletionBlock
     ) -> URLSessionDataTask? {
 
         guard
-            let bundleIdentifier = bundle.bundleIdentifier,
-            let url = URL(string: "https://itunes.apple.com/lookup?bundleId=\(bundleIdentifier)")
+            let bundleIdentifier = bundle.bundleIdentifier
         else {
+            callbackQueue.async {
+                completion(Result.failure(PoVError.invalidJsonData))
+            }
+            return nil
+        }
+
+        var urlString = "https://itunes.apple.com/lookup?bundleId=\(bundleIdentifier)"
+
+        // Append the country parameter if provided
+        if let country = country {
+            urlString += "&country=\(country)"
+        }
+
+        guard let url = URL(string: urlString) else {
             callbackQueue.async {
                 completion(Result.failure(PoVError.invalidJsonData))
             }


### PR DESCRIPTION
The App Store Lookup API defaults to the U.S. store (country=us) if no country parameter is specified. If your app isn't available in the U.S. store, this would result in an empty response. 
By appending country in the URL, the API will query the country store, where your app is available, thus returning the expected data.