### PR TITLE
Make sure each closure is called only once.

### DIFF
--- a/Sources/PrinceOfVersions/ResponseModels/UpdateData/UpdateInfo.swift
+++ b/Sources/PrinceOfVersions/ResponseModels/UpdateData/UpdateInfo.swift
@@ -78,6 +78,7 @@ public struct UpdateInfo: Decodable {
 
     internal var userRequirements: [String: ((Any) -> Bool)] = [:] {
         didSet {
+            if oldValue.keys == userRequirements.keys { return }
             configuration = configurations?.first { meetsUserRequirements($0.requirements) }
         }
     }

--- a/Sources/PrinceOfVersions/ResponseModels/UpdateData/UpdateInfo.swift
+++ b/Sources/PrinceOfVersions/ResponseModels/UpdateData/UpdateInfo.swift
@@ -78,7 +78,7 @@ public struct UpdateInfo: Decodable {
 
     internal var userRequirements: [String: ((Any) -> Bool)] = [:] {
         didSet {
-            if oldValue.keys == userRequirements.keys { return }
+            if oldValue.keys == userRequirements.keys && configuration != nil { return }
             configuration = configurations?.first { meetsUserRequirements($0.requirements) }
         }
     }


### PR DESCRIPTION
## Summary

After an issue was opened, I validated it and confirmed that the library indeed performs unnecessary checks multiple times.

**Related issue**: [#40](https://github.com/infinum/ios-prince-of-versions/issues/40)

## Changes

Add check for userRequirements.keys and call meetsUserRequirements only if the dictionary truly changes (either in size or in keys).

### Type

- [ ] **Feature**: This pull request introduces a new feature.
- [x] **Bug fix**: This pull request fixes a bug.
- [ ] **Refactor**: This pull request refactors existing code.
- [ ] **Documentation**: This pull request updates documentation.
- [ ] **Other**: This pull request makes other changes.

#### Additional information

- [ ] This pull request introduces a **breaking change**.

### Description

Check the issue for incorrect behavior. Even though this didn't affect the requirement checks, it is a good optimization of the meetsUserRequirements method.

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have tested my changes, including edge cases.
- [ ] I have added necessary tests for the changes introduced (if applicable).
- [ ] I have updated the documentation to reflect my changes (if applicable).