### PR TITLE
Add and deprecate legacy addRequirement method for backward compatibility.

### DIFF
--- a/Sources/PrinceOfVersions/PoVDataTypes/PoVRequestOptions.swift
+++ b/Sources/PrinceOfVersions/PoVDataTypes/PoVRequestOptions.swift
@@ -36,6 +36,24 @@ public class PoVRequestOptions: NSObject {
      Use this method to add custom requirement by which configuration must comply with.
 
      - parameter key: String that matches key in requirements array in JSON with `requirementsCheck` parameter,
+     - parameter requirementCheck: A block used to check if a configuration meets the requirement. This block returns `true` if the configuration meets the requirement, and takes the value as input.
+
+     - Warning: Deprecated. Use `addRequirement<T>(key:ofType:requirementCheck:)` instead.
+     */
+    @available(*, deprecated, message: "Use the generic version `addRequirement<T>(key:ofType:requirementCheck:)` instead.")
+    public func addRequirement(
+        key: String,
+        requirementCheck: @escaping ((Any) -> Bool)
+    ) {
+        userRequirements.updateValue(requirementCheck, forKey: key)
+    }
+
+    /**
+     Adds requirement check for configuration.
+
+     Use this method to add custom requirement by which configuration must comply with.
+
+     - parameter key: String that matches key in requirements array in JSON with `requirementsCheck` parameter,
      - parameter type: The expected type of the value.
      - parameter requirementCheck: A block used to check if a configuration meets the requirement. This block returns `true` if the configuration meets the requirement, and takes the typed value as input.
 


### PR DESCRIPTION
## Summary

Add backward-compatible `addRequirement` method and deprecate it in favor of the generic version `addRequirement<T>(key:ofType:requirementCheck:)`.

### Type

- [ ] **Feature**: This pull request introduces a new feature.
- [x] **Bug fix**: This pull request fixes a bug.
- [ ] **Refactor**: This pull request refactors existing code.
- [ ] **Documentation**: This pull request updates documentation.
- [ ] **Other**: This pull request makes other changes.

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have tested my changes, including edge cases.
- [ ] I have added necessary tests for the changes introduced (if applicable).
- [ ] I have updated the documentation to reflect my changes (if applicable).
